### PR TITLE
FIXED: error importing package message

### DIFF
--- a/templates/int/handler.gotpl
+++ b/templates/int/handler.gotpl
@@ -4,7 +4,7 @@ package {{pkg .Table}}
 import (
 	"{{index .PackageRoutes "package_name"}}/internal/logger"
 	"{{index .PackageRoutes "package_name"}}/internal/models"
-	"{{index .PackageRoutes "package_name"}}internal/messages"
+	"{{index .PackageRoutes "package_name"}}/internal/messages"
 	"github.com/jmoiron/sqlx"
 	"net/http"
 	"strconv"

--- a/templates/int64/handler.gotpl
+++ b/templates/int64/handler.gotpl
@@ -4,7 +4,7 @@ package {{pkg .Table}}
 import (
 	"{{index .PackageRoutes "package_name"}}/internal/logger"
 	"{{index .PackageRoutes "package_name"}}/internal/models"
-	"{{index .PackageRoutes "package_name"}}internal/messages"
+	"{{index .PackageRoutes "package_name"}}/internal/messages"
 	"github.com/jmoiron/sqlx"
 	"net/http"
 	"strconv"

--- a/templates/uuid/handler.gotpl
+++ b/templates/uuid/handler.gotpl
@@ -4,7 +4,7 @@ package {{pkg .Table}}
 import (
 	"{{index .PackageRoutes "package_name"}}/internal/logger"
 	"{{index .PackageRoutes "package_name"}}/internal/models"
-	"{{index .PackageRoutes "package_name"}}internal/messages"
+	"{{index .PackageRoutes "package_name"}}/internal/messages"
 	"github.com/jmoiron/sqlx"
 	"github.com/google/uuid"
 	"github.com/asaskevich/govalidator"


### PR DESCRIPTION
Error importing package “{{index .PackageRoutes ‘package_name’}}/internal/messages”.
 was fixed in the three types of identifier generation, “uuid”, “int”, “int64”